### PR TITLE
Remove `getDNS` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ This project wraps a part of Node.js's [dns module](https://nodejs.org/api/dns.h
 - [**getServers()**](https://nodejs.org/api/dns.html#dns_dns_getservers) - *returns an array of IP addresses which are configured for DNS lookups*
 - [**setServers(servers)**](https://nodejs.org/api/dns.html#dns_dns_setservers_servers) - *configures an array of IP addresses which are configured for DNS lookups*
 - [**getIP(hostname)**](https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback) - *returns a promise which will resolve to either `undefined` or the IP address*
-- [**getDNS(hostname)**](https://nodejs.org/api/dns.html#dns_dns_resolveany_hostname_callback) - *returns a promise which will resolve to either `undefined` or an array of DNS records*
 - [**getNS(hostname)**](https://nodejs.org/api/dns.html#dns_dns_resolvens_hostname_callback) - *returns a promise which will resolve to either `undefined` or an array of nameservers*
 - [**reverseDNS(ip)**](https://nodejs.org/api/dns.html#dns_dns_reverse_ip_callback) - *returns a promise which will resolve to either `undefined` or an array of hostnames*
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,22 +18,6 @@ export const getIP = (hostname: string): Promise<string | undefined> => {
 };
 
 /**
- * Get all DNS records associated with a hostname.
- * @param hostname
- */
-export const getDNS = (hostname: string): Promise<dns.AnyRecord[] | undefined> => {
-    return new Promise(resolve => {
-        dns.resolveAny(url.parse(hostname).hostname || hostname, (error, records) => {
-            if (error) {
-                return resolve(undefined);
-            }
-
-            resolve(records);
-        });
-    });
-};
-
-/**
  * Get the name servers associated with a hostname.
  * @param hostname
  */


### PR DESCRIPTION
Implementation of the `resolveAny` method depends on the DNS server and is not used by CSDB.